### PR TITLE
Extend json support for market books

### DIFF
--- a/betfairlightweight/resources/bettingresources.py
+++ b/betfairlightweight/resources/bettingresources.py
@@ -1,4 +1,5 @@
 from .baseresource import BaseResource
+from .streamingresources import MarketDefinition
 
 
 class EventType:
@@ -561,6 +562,17 @@ class MarketBook(BaseResource):
     :type version: int
     """
 
+    @classmethod
+    def from_json(cls, json_data: str):
+        data = json.loads(json_data)
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: Dict):
+        market_definition = MarketDefinition(**data.pop("market_definition"))
+        kwargs = {**data, "market_definition": market_definition}
+        return cls(**kwargs)
+
     def __init__(self, **kwargs):
         self.streaming_unique_id = kwargs.pop("streaming_unique_id", None)
         self.streaming_update = kwargs.pop("streaming_update", None)
@@ -595,6 +607,14 @@ class MarketBook(BaseResource):
             if kwargs.get("priceLadderDefinition")
             else None
         )
+    
+    def json(self) -> str:
+        extra_fields = {
+            "market_definition": self.market_definition.json(),
+            "streaming_unique_id": self.streaming_unique_id,
+            "streaming_update": self.streaming_update
+        }
+        return json.dumps({**self._data, **extra_fields})
 
 
 class CurrentOrder:

--- a/betfairlightweight/resources/streamingresources.py
+++ b/betfairlightweight/resources/streamingresources.py
@@ -170,3 +170,49 @@ class MarketDefinition:
 
         self.name = name  # historic data only
         self.event_name = eventName  # historic data only
+
+        self._data = {
+            "betDelay": betDelay
+            "bettingType": bettingType
+            "bspMarket": bspMarket
+            "bspReconciled": bspReconciled
+            "complete": complete
+            "crossMatching": crossMatching
+            "discountAllowed": discountAllowed
+            "eventId": eventId
+            "eventTypeId": eventTypeId
+            "inPlay": inPlay
+            "marketBaseRate": marketBaseRate
+            "marketTime": marketTime
+            "numberOfActiveRunners": numberOfActiveRunners
+            "numberOfWinners": numberOfWinners
+            "persistenceEnabled": persistenceEnabled
+            "regulators": regulators
+            "runnersVoidable": runnersVoidable
+            "status": status
+            "timezone": timezone
+            "turnInPlayEnabled": turnInPlayEnabled
+            "version": version
+            "runners": runners
+            "openDate": openDate
+            "countryCode": countryCode
+            "eachWayDivisor": eachWayDivisor
+            "venue": venue
+            "settledTime": settledTime
+            "suspendTime": suspendTime
+            "marketType": marketType
+            "lineMaxUnit": lineMaxUnit
+            "lineMinUnit": lineMinUnit
+            "lineInterval": lineInterval
+            "name": name
+            "eventName": eventName
+            "priceLadderDefinition": priceLadderDefinition
+            "keyLineDefinition": keyLineDefinition
+            "raceType": raceType
+        }
+
+        def json(self):
+            # Dump to dict rather than string because this will
+            # typically be called by the Marketbook dump which 
+            # will include this dict in the json string it produces
+            return json.dump(self._data)


### PR DESCRIPTION
The json dumping of the MarketBook class has been expanded to
include a json dump of its MarketDefinition. JSON to
Marketbook conversion has also been added so a full MarketBook
can be added reproduced from a MarketBook json dump.