### PR TITLE
Remove MarketBook loading from json

### DIFF
--- a/betfairlightweight/resources/bettingresources.py
+++ b/betfairlightweight/resources/bettingresources.py
@@ -1,5 +1,4 @@
 from .baseresource import BaseResource
-from .streamingresources import MarketDefinition
 
 
 class EventType:
@@ -561,17 +560,6 @@ class MarketBook(BaseResource):
     :type total_matched: float
     :type version: int
     """
-
-    @classmethod
-    def from_json(cls, json_data: str):
-        data = json.loads(json_data)
-        return cls.from_dict(data)
-
-    @classmethod
-    def from_dict(cls, data: Dict):
-        market_definition = MarketDefinition(**data.pop("market_definition"))
-        kwargs = {**data, "market_definition": market_definition}
-        return cls(**kwargs)
 
     def __init__(self, **kwargs):
         self.streaming_unique_id = kwargs.pop("streaming_unique_id", None)


### PR DESCRIPTION
Loading from json requires an import of MarketDefinition but
this causes import conflicts. This could be fixed by moving
MarketDefinition to a new module but I want to keep this
fork as close as possible to the original repo so I have
just removed the json loading. The loading will how have to
be performed manually where required.